### PR TITLE
Fix Patch 20231031 and improve Error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -199,13 +199,15 @@ function doCommand(list, req, cb) {
       cb();
    } else {
       let command = list.shift();
-      if (command == "" || command == "\n") {
+      // Test for any non white space character, if none found skip
+      if (!/\S/.test(command)) {
          doCommand(list, req, cb);
          return;
       }
       // console.log(command);
       req.queryIsolate(command, [], (err, results) => {
-         if (err) {
+         // Ignore empty query error
+         if (err && err.code !== "ER_EMPTY_QUERY") {
             err.sql = command;
             cb(err);
             return;

--- a/patches/20231031.sql
+++ b/patches/20231031.sql
@@ -7,10 +7,11 @@
 
 # Dump of table SITE_KEY
 # ------------------------------------------------------------
+-- FIX: Error Code: 1451. Cannot delete or update a parent row: a foreign key constraint fails
+-- when the table already exists
+-- DROP TABLE IF EXISTS `SITE_KEY`;
 
-DROP TABLE IF EXISTS `SITE_KEY`;
-
-CREATE TABLE `SITE_KEY` (
+CREATE TABLE IF NOT EXISTS `SITE_KEY` (
   `uuid` varchar(255) NOT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
@@ -88,4 +89,3 @@ ON DUPLICATE KEY UPDATE
     updatedAt = VALUES(updatedAt);    
 
 UNLOCK TABLES;
-


### PR DESCRIPTION
## Issue

Patch `20231031.sql` fails with code: `'ER_EMPTY_QUERY'`, because we try to run the whitespace `'\n\n'` as an sql command
<details><summary>Error</summary>
<p>

```
Error: ER_EMPTY_QUERY: Query was empty
    at Sequence._packetToError (/app/node_modules/mysql/lib/protocol/sequences/Sequence.js:47:14)
    at Query.ErrorPacket (/app/node_modules/mysql/lib/protocol/sequences/Query.js:79:18)
    at Protocol._parsePacket (/app/node_modules/mysql/lib/protocol/Protocol.js:291:23)
    at Parser._parsePacket (/app/node_modules/mysql/lib/protocol/Parser.js:433:10)
    at Parser.write (/app/node_modules/mysql/lib/protocol/Parser.js:43:10)
    at Protocol.write (/app/node_modules/mysql/lib/protocol/Protocol.js:38:16)
    at Socket.<anonymous> (/app/node_modules/mysql/lib/Connection.js:88:28)
    at Socket.<anonymous> (/app/node_modules/mysql/lib/Connection.js:526:10)
    at Socket.emit (node:events:513:28)
    at Socket.emit (node:domain:489:12)
    --------------------
    at Pool.query (/app/node_modules/mysql/lib/Pool.js:199:23)
    at /app/node_modules/@digiserve/ab-utils/utils/reqService.js:630:28
    at new Promise (<anonymous>)
    at /app/node_modules/@digiserve/ab-utils/utils/reqService.js:629:17
    at ABRequestService.retry (/app/node_modules/@digiserve/ab-utils/utils/reqService.js:748:14)
    at ABRequestService.query (/app/node_modules/@digiserve/ab-utils/utils/reqService.js:628:12)
    at ABRequestService.queryIsolate (/app/node_modules/@digiserve/ab-utils/utils/reqService.js:668:12)
    at doCommand (/app/app.js:200:11)
    at /app/app.js:201:37
    at /app/node_modules/@digiserve/ab-utils/utils/reqService.js:649:13 {
  code: 'ER_EMPTY_QUERY',
  errno: 1065,
  sqlMessage: 'Query was empty',
  sqlState: '42000',
  index: 0,
  sql: '\n\n'
}
``` 

</p>
</details> 
</details> 

On subsequent runs we get an error `Error Code: 1451. Cannot delete or update a parent row: a foreign key constraint fails` with the SQL Command: ``DROP TABLE IF EXISTS `SITE_KEY`;``

## Changes
- Fix the above errors in patch `20231031.sql`
- Improve the checks for empty commands
- Ignores empty query errors
- Save the previous patch as completed if the current patch fails.

